### PR TITLE
Fix syntax in shader squarelamp_blue_40k

### DIFF
--- a/scripts/parpax_custom.shader
+++ b/scripts/parpax_custom.shader
@@ -298,8 +298,6 @@ textures/parpax_custom/squarelamp_blue_40k
 
 	{
 		diffuseMap  textures/parpax_custom_src/squarelamp_blue_d
-	}
-	{
 		glowMap     textures/parpax_custom_src/squarelamp_blue_a
 	}
 }


### PR DESCRIPTION
I didn't test it and don't understand what's correct; just copied the one above it.

This is to fix `^3Warn: Shader textures/parpax_custom/squarelamp_blue_40k has a colormap stage with no image`