### PR TITLE
materials: reuse ex normal and specular map

### DIFF
--- a/scripts/parpax_exm.shader
+++ b/scripts/parpax_exm.shader
@@ -10,7 +10,7 @@ textures/parpax_exm/base1_nonsolid
 
 	{
 		diffuseMap textures/shared_exm_src/base1_d
-		normalMap textures/shared_exm_src/base1_n
-		specularMap textures/shared_exm_src/base1_s
+		normalMap textures/shared_ex_src/base1_n
+		specularMap textures/shared_ex_src/base1_s
 	}
 }


### PR DESCRIPTION
This is needed once `tex-ex` and `tex-exm` are deduplicated:

- https://github.com/UnvanquishedAssets/tex-exm_src.dpkdir/pull/2